### PR TITLE
feat: send annotations

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,6 +1,8 @@
 package opentelemetrygithubactionsannotationsreceiver
 
 import (
+	"time"
+
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configopaque"
 )
@@ -10,4 +12,15 @@ type Config struct {
 	Path                    string
 	WebhookSecret           configopaque.String `mapstructure:"webhook_secret"`
 	Token                   configopaque.String `mapstructure:"token"`
+	Retry                   RetryConfig         `mapstructure:"retry"`
+	BatchSize               int                 `mapstructure:"batch_size"`
+	CustomServiceName       string              `mapstructure:"custom_service_name"`
+	ServiceNamePrefix       string              `mapstructure:"service_name_prefix"`
+	ServiceNameSuffix       string              `mapstructure:"service_name_suffix"`
+}
+
+type RetryConfig struct {
+	InitialInterval time.Duration `mapstructure:"initial_interval"`
+	MaxInterval     time.Duration `mapstructure:"max_interval"`
+	MaxElapsedTime  time.Duration `mapstructure:"max_elapsed_time"`
 }

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,14 @@ module github.com/v1v/opentelemetry-github-actions-annotations-receiver
 go 1.23.2
 
 require (
+	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/google/go-github/v66 v66.0.0
 	github.com/julienschmidt/httprouter v1.3.0
 	go.opentelemetry.io/collector/component v0.102.0
 	go.opentelemetry.io/collector/config/confighttp v0.102.0
 	go.opentelemetry.io/collector/config/configopaque v1.9.0
 	go.opentelemetry.io/collector/consumer v0.102.0
+	go.opentelemetry.io/collector/pdata v1.9.0
 	go.opentelemetry.io/collector/receiver v0.102.0
 	go.uber.org/zap v1.27.0
 )
@@ -45,7 +47,6 @@ require (
 	go.opentelemetry.io/collector/extension v0.102.0 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.102.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.9.0 // indirect
-	go.opentelemetry.io/collector/pdata v1.9.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.52.0 // indirect
 	go.opentelemetry.io/otel v1.27.0 // indirect
 	go.opentelemetry.io/otel/metric v1.27.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
+github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -105,6 +107,8 @@ go.opentelemetry.io/collector/featuregate v1.9.0 h1:mC4/HnR5cx/kkG1RKOQAvHxxg5Kt
 go.opentelemetry.io/collector/featuregate v1.9.0/go.mod h1:PsOINaGgTiFc+Tzu2K/X2jP+Ngmlp7YKGV1XrnBkH7U=
 go.opentelemetry.io/collector/pdata v1.9.0 h1:qyXe3HEVYYxerIYu0rzgo1Tx2d1Zs6iF+TCckbHLFOw=
 go.opentelemetry.io/collector/pdata v1.9.0/go.mod h1:vk7LrfpyVpGZrRWcpjyy0DDZzL3SZiYMQxfap25551w=
+go.opentelemetry.io/collector/pdata/testdata v0.102.0 h1:hDTnmWPWWFtGHdZM/II8G9RW2nInvRoCIwBe3ekdDxg=
+go.opentelemetry.io/collector/pdata/testdata v0.102.0/go.mod h1:JEoSJTMgeTKyGxoMRy48RMYyhkA5vCCq/abJq9B6vXs=
 go.opentelemetry.io/collector/receiver v0.102.0 h1:8rHNjWjV90bL0dgvKVc/7D10NCbM7bXCiqpcLRz5jBI=
 go.opentelemetry.io/collector/receiver v0.102.0/go.mod h1:bYDwYItMrj7Drx0Pn4wZQ8Ii67lp9Nta62gbau93FhA=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.52.0 h1:9l89oX4ba9kHbBol3Xin3leYJ+252h0zszDtBwyKe2A=

--- a/logs.go
+++ b/logs.go
@@ -1,0 +1,58 @@
+package opentelemetrygithubactionsannotationsreceiver
+
+import (
+	"time"
+
+	"github.com/google/go-github/v66/github"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+func attachData(logRecord *plog.LogRecord, repository Repository, run Run, logLine LogLine) error {
+	logRecord.SetSeverityNumber(plog.SeverityNumber(logLine.SeverityNumber))
+	logRecord.SetSeverityText(logLine.SeverityText)
+	if err := attachTraceId(logRecord, run); err != nil {
+		return err
+	}
+	logRecord.SetTimestamp(pcommon.NewTimestampFromTime(logLine.Timestamp))
+	logRecord.SetObservedTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	logRecord.Body().SetStr(logLine.Body)
+	attachRepositoryAttributes(logRecord, repository)
+	attachRunAttributes(logRecord, run)
+	return nil
+}
+
+// parseAnnotationToLogLine parses an annotation from the GitHub Actions log file
+func parseAnnotationToLogLine(completedAt time.Time, line *github.CheckRunAnnotation) LogLine {
+	var severityNumber = 0 // Unspecified
+	return LogLine{
+		Body:           line.GetMessage(),
+		Timestamp:      completedAt,
+		SeverityNumber: severityNumber,
+		SeverityText:   line.GetAnnotationLevel(),
+	}
+}
+
+func attachTraceId(logRecord *plog.LogRecord, run Run) error {
+	traceId, err := generateTraceID(run.ID, int(run.RunAttempt))
+	if err != nil {
+		return err
+	}
+	logRecord.SetTraceID(traceId)
+	return nil
+}
+
+func attachRepositoryAttributes(logRecord *plog.LogRecord, repository Repository) {
+	logRecord.Attributes().PutStr("github.repository", repository.FullName)
+}
+
+func attachRunAttributes(logRecord *plog.LogRecord, run Run) {
+	logRecord.Attributes().PutInt("github.workflow_run.id", run.ID)
+	logRecord.Attributes().PutInt("github.workflow_run.run_attempt", run.RunAttempt)
+	logRecord.Attributes().PutStr("github.workflow_run.conclusion", run.Conclusion)
+	logRecord.Attributes().PutStr("github.workflow_run.status", run.Status)
+	logRecord.Attributes().PutStr("github.workflow_run.run_started_at", pcommon.NewTimestampFromTime(run.RunStartedAt).String())
+	logRecord.Attributes().PutStr("github.workflow_run.created_at", pcommon.NewTimestampFromTime(run.CreatedAt).String())
+	logRecord.Attributes().PutStr("github.workflow_run.completed_at", pcommon.NewTimestampFromTime(run.CompletedAt).String())
+	logRecord.Attributes().PutStr("github.workflow_run.head_branch", run.HeadBranch)
+}

--- a/model.go
+++ b/model.go
@@ -1,0 +1,54 @@
+package opentelemetrygithubactionsannotationsreceiver
+
+import (
+	"time"
+
+	"github.com/google/go-github/v66/github"
+)
+
+type LogLine struct {
+	Body           string
+	Timestamp      time.Time
+	SeverityNumber int
+	SeverityText   string
+}
+
+type Repository struct {
+	FullName string
+	Org      string
+	Name     string
+}
+
+type Run struct {
+	ID           int64
+	RunAttempt   int64     `json:"run_attempt"`
+	RunStartedAt time.Time `json:"run_started_at"`
+	URL          string    `json:"html_url"`
+	Status       string
+	Conclusion   string
+	CreatedAt    time.Time `json:"created_at"`
+	CompletedAt  time.Time `json:"completed_at"`
+	HeadBranch   string
+}
+
+func mapRun(run *github.WorkflowJob) Run {
+	return Run{
+		ID:           *run.RunID,
+		RunAttempt:   int64(*run.RunAttempt),
+		URL:          *run.RunURL,
+		Status:       *run.Status,
+		Conclusion:   *run.Conclusion,
+		RunStartedAt: run.StartedAt.Time,
+		CreatedAt:    run.CreatedAt.Time,
+		CompletedAt:  run.CompletedAt.Time,
+		HeadBranch:   run.GetHeadBranch(),
+	}
+}
+
+func mapRepository(repo *github.Repository) Repository {
+	return Repository{
+		FullName: repo.GetFullName(),
+		Org:      repo.GetOwner().GetLogin(),
+		Name:     repo.GetName(),
+	}
+}

--- a/traces.go
+++ b/traces.go
@@ -1,0 +1,38 @@
+package opentelemetrygithubactionsannotationsreceiver
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+// generateTraceID generates a trace ID from the run ID and run attempt
+// Copied from https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/b45f1739c29039a0314b9c97c3ccc578562df36f/receiver/githubactionsreceiver/trace_event_handling.go#L212
+// to be able to correlate logs with traces from the githubactionsreceiver
+func generateTraceID(runID int64, runAttempt int) (pcommon.TraceID, error) {
+	input := fmt.Sprintf("%d%dt", runID, runAttempt)
+	hash := sha256.Sum256([]byte(input))
+	traceIDHex := hex.EncodeToString(hash[:])
+
+	var traceID pcommon.TraceID
+	_, err := hex.Decode(traceID[:], []byte(traceIDHex[:32]))
+	if err != nil {
+		return pcommon.TraceID{}, err
+	}
+
+	return traceID, nil
+}
+
+// generateServiceName generates a service name from the full name of the repository
+// Copied from https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/b45f1739c29039a0314b9c97c3ccc578562df36f/receiver/githubactionsreceiver/trace_event_handling.go#L254
+// to be able to correlate logs with traces from the githubactionsreceiver
+func generateServiceName(config *Config, fullName string) string {
+	if config.CustomServiceName != "" {
+		return config.CustomServiceName
+	}
+	formattedName := strings.ToLower(strings.ReplaceAll(strings.ReplaceAll(fullName, "/", "-"), "_", "-"))
+	return fmt.Sprintf("%s%s%s", config.ServiceNamePrefix, formattedName, config.ServiceNameSuffix)
+}


### PR DESCRIPTION
I ran https://github.com/elastic-robots/generator/actions/runs/11345196644

and it produced

```
2024-10-15T13:34:36.247+0200	info	githubactionsannotationsreceiver@v0.102.0/receiver.go:129	Starting to process webhook event	{"kind": "receiver", "name": "githubactionsannotations", "data_type": "logs", "github.repository": "elastic-robots/generator", "github.workflow_run.name": "test-annotations", "github.workflow_run.id": 11334029374, "github.workflow_run.run_attempt": 5}
2024-10-15T13:34:36.553+0200	info	githubactionsannotationsreceiver@v0.102.0/receiver.go:200	Successfully consumed annotations	{"kind": "receiver", "name": "githubactionsannotations", "data_type": "logs", "github.repository": "elastic-robots/generator", "github.workflow_run.name": "test-annotations", "github.workflow_run.id": 11334029374, "github.workflow_run.run_attempt": 5, "log_record_count": 4}
2024-10-15T13:34:36.557+0200	info	LogsExporter	{"kind": "exporter", "data_type": "logs", "name": "debug", "resource logs": 1, "log records": 4}
2024-10-15T13:34:39.537+0200	debug	githubactionsannotationsreceiver@v0.102.0/receiver.go:112	Handling workflow job event	{"kind": "receiver", "name": "githubactionsannotations", "data_type": "logs", "workflow_job.id": 31551542926}
2024-10-15T13:34:39.537+0200	info	githubactionsannotationsreceiver@v0.102.0/receiver.go:129	Starting to process webhook event	{"kind": "receiver", "name": "githubactionsannotations", "data_type": "logs", "github.repository": "elastic-robots/generator", "github.workflow_run.name": "test-annotations", "github.workflow_run.id": 11345196644, "github.workflow_run.run_attempt": 1}
2024-10-15T13:34:39.756+0200	info	githubactionsannotationsreceiver@v0.102.0/receiver.go:200	Successfully consumed annotations	{"kind": "receiver", "name": "githubactionsannotations", "data_type": "logs", "github.repository": "elastic-robots/generator", "github.workflow_run.name": "test-annotations", "github.workflow_run.id": 11345196644, "github.workflow_run.run_attempt": 1, "log_record_count": 1}
2024-10-15T13:34:39.771+0200	info	LogsExporter	{"kind": "exporter", "data_type": "logs", "name": "debug", "resource logs": 1, "log records": 1}


```